### PR TITLE
Fix CaptureToStaticTransformer tests

### DIFF
--- a/ILDynamics/Resolver/Resolver.cs
+++ b/ILDynamics/Resolver/Resolver.cs
@@ -63,6 +63,19 @@ namespace ILDynamics.Resolver
             for (int i = 0; i < args.Length; i++)
                 args[i] = argsofm[i].ParameterType;
 
+            if (filters != null)
+            {
+                foreach (var f in filters)
+                {
+                    if (f is Filters.CaptureToStaticTransformer)
+                    {
+                        var extra = Filters.CaptureToStaticTransformer.GetCapturedFieldType(m);
+                        if (extra != null)
+                            args = args.Concat(new[] { extra }).ToArray();
+                    }
+                }
+            }
+
             MethodBuilder factory = demoType.DefineMethod("DynamicMethod",
                 MethodAttributes.Public | MethodAttributes.Static,
                 m.ReturnType,


### PR DESCRIPTION
## Summary
- add helper to inspect captured field type
- extend `Resolver.CopyMethod` to append captured value parameter when using `CaptureToStaticTransformer`
- handle argument index remapping and generic operand support inside the transformer
- run full test suite

## Testing
- `dotnet test -v minimal`
- `dotnet test --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6842bab0b8d0832aaaaea98099c252b3