### PR TITLE
Add extensive CaptureToStaticTransformer tests

### DIFF
--- a/ILDynamics/Resolver/Resolver.cs
+++ b/ILDynamics/Resolver/Resolver.cs
@@ -69,9 +69,9 @@ namespace ILDynamics.Resolver
                 {
                     if (f is Filters.CaptureToStaticTransformer)
                     {
-                        var extra = Filters.CaptureToStaticTransformer.GetCapturedFieldType(m);
-                        if (extra != null)
-                            args = args.Concat(new[] { extra }).ToArray();
+                        var extras = Filters.CaptureToStaticTransformer.GetCapturedFieldTypes(m);
+                        if (extras.Length > 0)
+                            args = args.Concat(extras).ToArray();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- support multiple captured fields in `CaptureToStaticTransformer`
- keep non-capturing lambdas and ordinary methods unchanged
- adjust resolver to append all captured parameters
- update tests for new behaviour

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842bf4122d8832a9b5759f5f168d1ba