### PR TITLE
Add MethodInfo decompile extension

### DIFF
--- a/ILDynamics.Tests/MethodInfoExtensionsTests.cs
+++ b/ILDynamics.Tests/MethodInfoExtensionsTests.cs
@@ -44,5 +44,13 @@ namespace ILDynamics.Tests
             string sig = mi.GetDelegateSignature();
             Assert.AreEqual("Func<Int32> NoParams", sig);
         }
+
+        [TestMethod]
+        public void Test_DecompileToString()
+        {
+            MethodInfo mi = typeof(MethodInfoExtensionsTests).GetMethod(nameof(Add));
+            string code = mi.DecompileToString();
+            Assert.IsTrue(code.Contains("Add"));
+        }
     }
 }

--- a/ILDynamics/ILDynamics.csproj
+++ b/ILDynamics/ILDynamics.csproj
@@ -28,4 +28,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/ILDynamics/MethodInfoExtensions.cs
+++ b/ILDynamics/MethodInfoExtensions.cs
@@ -2,6 +2,10 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.Metadata;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler;
 
 namespace ILDynamics
 {
@@ -47,6 +51,22 @@ namespace ILDynamics
             }
 
             return $"{delegateType} {method.Name}";
+        }
+
+        /// <summary>
+        /// Decompiles the method body into a C# string using ILSpy's decompiler.
+        /// </summary>
+        public static string DecompileToString(this MethodInfo method)
+        {
+            if (string.IsNullOrEmpty(method.Module.FullyQualifiedName))
+            {
+                throw new ArgumentException("Method must belong to a physical module.");
+            }
+
+            var decompiler = new CSharpDecompiler(method.Module.FullyQualifiedName, new DecompilerSettings());
+            var handle = MetadataTokens.MethodDefinitionHandle(method.MetadataToken);
+            EntityHandle entity = handle;
+            return decompiler.DecompileAsString(new[] { entity });
         }
     }
 }


### PR DESCRIPTION
## Summary
- use ICSharpCode.Decompiler via package reference
- add MethodInfo.DecompileToString extension
- add corresponding unit test

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842ea70f4fc832aac58322eb2dc5023